### PR TITLE
Remove redundant top_keywords field from API response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/hisa-git/html_parsing_backend/issues/1
-Your prepared branch: issue-1-71bc9df5
-Your prepared working directory: /tmp/gh-issue-solver-1758976835116
-Your forked repository: konard/html_parsing_backend
-Original repository (upstream): hisa-git/html_parsing_backend
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/hisa-git/html_parsing_backend/issues/1
+Your prepared branch: issue-1-71bc9df5
+Your prepared working directory: /tmp/gh-issue-solver-1758976835116
+Your forked repository: konard/html_parsing_backend
+Original repository (upstream): hisa-git/html_parsing_backend
+
+Proceed.

--- a/index.py
+++ b/index.py
@@ -109,7 +109,7 @@ def analyze_url(request: UrlRequest):
         
         content_analysis = analyze_text_content(soup)
         
-        print(f"Найдено ключевых слов: {len(content_analysis['top_keywords'])}")
+        print(f"Найдено ключевых слов: {len(content_analysis['keyword_density'])}")
         
         og_title = soup.find('meta', property='og:title')
         og_description = soup.find('meta', property='og:description')
@@ -146,7 +146,6 @@ def analyze_url(request: UrlRequest):
                 "char_count": content_analysis['char_count'],
                 "unique_words": content_analysis['unique_words'],
                 "language": content_analysis['language'],
-                "top_keywords": content_analysis['top_keywords'],
                 "keyword_density": content_analysis['keyword_density']
             },
             "technical": {

--- a/wordsanalyze.py
+++ b/wordsanalyze.py
@@ -109,7 +109,6 @@ def analyze_text_content(soup) -> Dict:
         return {
             'word_count': len(text_content.split()),
             'char_count': len(text_content),
-            'top_keywords': [],
             'keyword_density': [],
             'language': 'unknown',
             'unique_words': 0
@@ -130,7 +129,6 @@ def analyze_text_content(soup) -> Dict:
     return {
         'word_count': total_words,
         'char_count': len(text_content),
-        'top_keywords': [{'word': word, 'count': count} for word, count in word_frequency],
         'keyword_density': keyword_density,
         'language': detect_language(text_content),
         'unique_words': unique_words


### PR DESCRIPTION
## Summary
Fixes #1 - Removes excessive duplicate information from the API response.

## Problem
The backend was returning two arrays with redundant data:
- `top_keywords`: Array with word and count
- `keyword_density`: Array with word, count, and density

Since `keyword_density` already contains all information from `top_keywords` plus density percentage, `top_keywords` was redundant.

## Changes
- Removed `top_keywords` field from `wordsanalyze.py` return dictionary
- Removed `top_keywords` from `/analyze` endpoint response in `index.py`
- Updated debug log to reference `keyword_density` instead of `top_keywords`

## Result
API response now returns only `keyword_density` which contains:
- `word`: The keyword
- `count`: Occurrence count
- `density`: Percentage density

This eliminates duplicate data while maintaining all necessary information.

🤖 Generated with [Claude Code](https://claude.ai/code)